### PR TITLE
Remove spaces before @const & Bump svelte version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@sveltejs/vite-plugin-svelte": "^3.1.0",
     "@types/node": "^20.12.12",
     "publint": "^0.2.8",
-    "svelte": "^5.0.0-next.144",
+    "svelte": "^5.0.0-next.183",
     "svelte-check": "^3.8.0",
     "tslib": "^2.6.2",
     "typescript": "^5.0.0",

--- a/src/lib/comps/TopNav.svelte
+++ b/src/lib/comps/TopNav.svelte
@@ -18,8 +18,8 @@
         {@render Logo()}
         <ul class="topNavLinks" class:open={isSideNavOpen}>
             {#each topNavLinks as link }
-                { @const active = (link.href===$page.url.pathname && !link.external ) }
-                { @const attributes = { href:link.href, target:link.external?"_blank":"",onclick:closeTopNav } }
+                {@const active = (link.href===$page.url.pathname && !link.external )}
+                {@const attributes = { href:link.href, target:link.external?"_blank":"",onclick:closeTopNav }}
                 <li class="topNavLink">
                     <a class:active {...attributes}>
                         {link.text}


### PR DESCRIPTION
When using kitDocs i ran into an issue when i bumper by version Svelte5. 

The error message i was receiving, after these changes the build works great on `5.0.0-next.170`

```
Expected a `@` character immediately following the opening bracket [plugin vite-plugin-svelte:optimize-svelte]
```

The simple fix is to just remove the spaces from the code and also bump the version!

Thanks,
Jack!